### PR TITLE
Changed wiki to dict

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -37,5 +37,5 @@ sudo make install                                   # Install Wiki CLI to "/usr/
 ### User install
 If you don't have access to `sudo` on your system you can install to your user's `~/.local/bin` directory with this command: 
 ```bash
-install -Dt ~/.local/bin -m 755 wiki
+install -Dt ~/.local/bin -m 755 dict
 ```


### PR DESCRIPTION
Local install is supposed to be for "dict", not "wiki"