### PR TITLE
Language selection is no longer available

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,12 +32,8 @@ func main() {
 
     if len(os.Args) >= 2 {
         word = os.Args[1]
-
-        if len(os.Args) >= 3 {
-            lang = os.Args[2]
-        }
     } else {
-        log.Fatal("Usage: dict <Word> [<Language>]")
+        log.Fatal("Usage: dict <Word>")
     }
 
     resp, err := http.Get(parseWord(word))


### PR DESCRIPTION
According to this https://github.com/meetDeveloper/freeDictionaryAPI/issues/102 English is the only language that is now supported. Dict have an optional parameter to select language, since free dictionary API have already removed this feature, passing language code will return "No definitions found error"

![image](https://user-images.githubusercontent.com/71683721/174744177-f00e29a7-c850-4eeb-aeaf-7c542c8e3562.png)
